### PR TITLE
Implement user module

### DIFF
--- a/src/main/java/me/crypnotic/neutron/api/user/AbstractUser.java
+++ b/src/main/java/me/crypnotic/neutron/api/user/AbstractUser.java
@@ -1,0 +1,25 @@
+package me.crypnotic.neutron.api.user;
+
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public abstract class AbstractUser<T extends CommandSource> {
+
+    public abstract Optional<T> getBase();
+
+    public abstract void load() throws Exception;
+
+    public abstract void save() throws Exception;
+
+    public boolean isPlayer() {
+        return getBase().isPresent() && getBase().get() instanceof Player;
+    }
+
+    public abstract String getName();
+
+    public abstract Optional<UUID> getUUID();
+
+}

--- a/src/main/java/me/crypnotic/neutron/manager/ModuleManager.java
+++ b/src/main/java/me/crypnotic/neutron/manager/ModuleManager.java
@@ -42,6 +42,7 @@ import me.crypnotic.neutron.module.announcement.AnnouncementsModule;
 import me.crypnotic.neutron.module.command.CommandModule;
 import me.crypnotic.neutron.module.locale.LocaleModule;
 import me.crypnotic.neutron.module.serverlist.ServerListModule;
+import me.crypnotic.neutron.module.user.UserModule;
 import me.crypnotic.neutron.util.FileIO;
 import me.crypnotic.neutron.util.Strings;
 import net.kyori.text.TextComponent;
@@ -76,6 +77,7 @@ public class ModuleManager {
         modules.put(CommandModule.class, new CommandModule());
         modules.put(LocaleModule.class, new LocaleModule());
         modules.put(ServerListModule.class, new ServerListModule());
+        modules.put(UserModule.class, new UserModule());
 
         registerSerializers();
 

--- a/src/main/java/me/crypnotic/neutron/module/command/CommandWrapper.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/CommandWrapper.java
@@ -25,6 +25,7 @@
 package me.crypnotic.neutron.module.command;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
@@ -35,9 +36,11 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import me.crypnotic.neutron.NeutronPlugin;
 import me.crypnotic.neutron.api.Neutron;
+import me.crypnotic.neutron.api.user.AbstractUser;
 import me.crypnotic.neutron.module.locale.LocaleMessage;
 import me.crypnotic.neutron.module.locale.LocaleMessageTable;
 import me.crypnotic.neutron.module.locale.LocaleModule;
+import me.crypnotic.neutron.module.user.UserModule;
 import me.crypnotic.neutron.util.Strings;
 import net.kyori.text.TextComponent;
 
@@ -111,6 +114,14 @@ public abstract class CommandWrapper implements Command {
             }
         }
         return Strings.formatAndColor(message.getDefaultMessage(), values);
+    }
+
+    public Optional<AbstractUser> getUser(CommandSource source) {
+        UserModule module = getNeutron().getModuleManager().get(UserModule.class);
+        if (module.isEnabled()) {
+            return Optional.ofNullable(module.getUser(source));
+        }
+        return Optional.empty();
     }
 
     public abstract void handle(CommandSource source, CommandContext context) throws CommandExitException;

--- a/src/main/java/me/crypnotic/neutron/module/user/ConsoleUser.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/ConsoleUser.java
@@ -1,0 +1,40 @@
+package me.crypnotic.neutron.module.user;
+
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.ConsoleCommandSource;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.crypnotic.neutron.api.Neutron;
+import me.crypnotic.neutron.api.user.AbstractUser;
+import ninja.leaping.configurate.ConfigurationNode;
+
+import java.util.Optional;
+import java.util.UUID;
+
+// TODO: Consider whether this should support *any* CommandSource that isn't a player (ie plugin-provided CommandSources)
+@RequiredArgsConstructor
+public class ConsoleUser extends AbstractUser<ConsoleCommandSource> {
+
+    private final ConfigurationNode root;
+
+    @Getter
+    private String name;
+
+    @Override
+    public Optional<ConsoleCommandSource> getBase() {
+        return Optional.of(Neutron.getNeutron().getProxy().getConsoleCommandSource());
+    }
+
+    @Override
+    public void load() throws Exception {
+        name = root.getNode("name").getString("CONSOLE");
+    }
+
+    @Override
+    public void save() throws Exception { /* noop */ }
+
+    @Override
+    public Optional<UUID> getUUID() {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/me/crypnotic/neutron/module/user/ConsoleUser.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/ConsoleUser.java
@@ -27,7 +27,7 @@ public class ConsoleUser extends AbstractUser<ConsoleCommandSource> {
 
     @Override
     public void load() throws Exception {
-        name = root.getNode("name").getString("CONSOLE");
+        name = root.getNode("name").getString("Console");
     }
 
     @Override

--- a/src/main/java/me/crypnotic/neutron/module/user/PlayerData.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/PlayerData.java
@@ -8,11 +8,14 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 @Data
 class PlayerData {
 
-    // Persistent data
+    // Persistent data - this is saved to disk.
+
+    @Setting(comment = "The version of this config. Don't change this!")
+    private int configVersion = 1;
 
     @Setting(comment = "The player's last known username.")
     private String username;
 
-    // Non-persisted data
+    // Non-persisted data - this is not saved when the user is unloaded.
 
 }

--- a/src/main/java/me/crypnotic/neutron/module/user/PlayerData.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/PlayerData.java
@@ -1,0 +1,18 @@
+package me.crypnotic.neutron.module.user;
+
+import lombok.Data;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+@Data
+class PlayerData {
+
+    // Persistent data
+
+    @Setting(comment = "Last known username")
+    private String username;
+
+    // Non-persisted data
+
+}

--- a/src/main/java/me/crypnotic/neutron/module/user/PlayerData.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/PlayerData.java
@@ -10,7 +10,7 @@ class PlayerData {
 
     // Persistent data
 
-    @Setting(comment = "Last known username")
+    @Setting(comment = "The player's last known username.")
     private String username;
 
     // Non-persisted data

--- a/src/main/java/me/crypnotic/neutron/module/user/PlayerUser.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/PlayerUser.java
@@ -1,5 +1,6 @@
 package me.crypnotic.neutron.module.user;
 
+import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import lombok.RequiredArgsConstructor;
 import me.crypnotic.neutron.api.user.AbstractUser;
@@ -45,8 +46,11 @@ public class PlayerUser extends AbstractUser<Player> {
 
     @Override
     public void save() throws Exception {
-        node.setValue(data);
-        loader.save(node);
+        node = ConfigHelper.setSerializable(node, data);
+        // If serialization failed, don't delete the user's data
+        if (node != null) {
+            loader.save(node);
+        }
     }
 
     @Override

--- a/src/main/java/me/crypnotic/neutron/module/user/PlayerUser.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/PlayerUser.java
@@ -1,13 +1,10 @@
 package me.crypnotic.neutron.module.user;
 
-import com.google.common.reflect.TypeToken;
 import com.velocitypowered.api.proxy.Player;
 import lombok.RequiredArgsConstructor;
-import me.crypnotic.neutron.api.Neutron;
 import me.crypnotic.neutron.api.user.AbstractUser;
 import me.crypnotic.neutron.util.ConfigHelper;
 import me.crypnotic.neutron.util.FileIO;
-import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 
@@ -26,8 +23,7 @@ public class PlayerUser extends AbstractUser<Player> {
 
     private PlayerData data;
 
-    private File file = FileIO.getOrCreate(getNeutron().getDataFolderPath().resolve("users"), uuid.toString() + ".conf");
-    private HoconConfigurationLoader loader = HoconConfigurationLoader.builder().setFile(file).build();
+    private HoconConfigurationLoader loader;
     private CommentedConfigurationNode node;
 
     @Override
@@ -41,6 +37,8 @@ public class PlayerUser extends AbstractUser<Player> {
 
     @Override
     public void load() throws Exception {
+        File file = FileIO.getOrCreate(getNeutron().getDataFolderPath().resolve("users"), uuid.toString() + ".conf");
+        this.loader = HoconConfigurationLoader.builder().setFile(file).build();
         this.node = loader.load();
         this.data = ConfigHelper.getSerializable(node, new PlayerData());
     }

--- a/src/main/java/me/crypnotic/neutron/module/user/PlayerUser.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/PlayerUser.java
@@ -1,0 +1,68 @@
+package me.crypnotic.neutron.module.user;
+
+import com.google.common.reflect.TypeToken;
+import com.velocitypowered.api.proxy.Player;
+import lombok.RequiredArgsConstructor;
+import me.crypnotic.neutron.api.Neutron;
+import me.crypnotic.neutron.api.user.AbstractUser;
+import me.crypnotic.neutron.util.ConfigHelper;
+import me.crypnotic.neutron.util.FileIO;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.util.Optional;
+import java.util.UUID;
+
+import static me.crypnotic.neutron.api.Neutron.getNeutron;
+
+@RequiredArgsConstructor
+public class PlayerUser extends AbstractUser<Player> {
+
+    private final UUID uuid;
+    private WeakReference<Player> base;
+
+    private PlayerData data;
+
+    private File file = FileIO.getOrCreate(getNeutron().getDataFolderPath().resolve("users"), uuid.toString() + ".conf");
+    private HoconConfigurationLoader loader = HoconConfigurationLoader.builder().setFile(file).build();
+    private CommentedConfigurationNode node;
+
+    @Override
+    public Optional<Player> getBase() {
+        if (base == null || base.get() == null) {
+            getNeutron().getProxy().getPlayer(uuid).ifPresent(player -> base = new WeakReference<>(player));
+        }
+
+        return Optional.ofNullable(base.get());
+    }
+
+    @Override
+    public void load() throws Exception {
+        this.node = loader.load();
+        this.data = ConfigHelper.getSerializable(node, new PlayerData());
+    }
+
+    @Override
+    public void save() throws Exception {
+        node.setValue(data);
+        loader.save(node);
+    }
+
+    @Override
+    public String getName() {
+        Optional<Player> base = getBase();
+        if (base.isPresent()) {
+            return base.get().getUsername();
+        }
+
+        return data.getUsername();
+    }
+
+    @Override
+    public Optional<UUID> getUUID() {
+        return Optional.of(uuid);
+    }
+}

--- a/src/main/java/me/crypnotic/neutron/module/user/UserModule.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/UserModule.java
@@ -26,7 +26,7 @@ public class UserModule extends AbstractModule {
     }
 
     private void initCache() {
-        final int maxSize = getRootNode().getNode("cache", "maxSize").getInt(100);
+        final int maxSize = getRootNode().getNode("cache", "max-size").getInt(100);
         final int expiryMins = getRootNode().getNode("cache", "expiry").getInt(30);
 
         final CacheBuilder<UUID, PlayerUser> builder = CacheBuilder.newBuilder()

--- a/src/main/java/me/crypnotic/neutron/module/user/UserModule.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/UserModule.java
@@ -6,16 +6,12 @@ import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.api.proxy.Player;
 import me.crypnotic.neutron.api.module.AbstractModule;
 import me.crypnotic.neutron.api.user.AbstractUser;
-import me.crypnotic.neutron.util.FileIO;
-import ninja.leaping.configurate.ConfigurationNode;
-import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+// TODO: Should the module be responsible solely for storing data?
 public class UserModule extends AbstractModule {
 
     private LoadingCache<UUID, PlayerUser> playerUsers;

--- a/src/main/java/me/crypnotic/neutron/module/user/UserModule.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/UserModule.java
@@ -1,0 +1,98 @@
+package me.crypnotic.neutron.module.user;
+
+import com.google.common.cache.*;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.ConsoleCommandSource;
+import com.velocitypowered.api.proxy.Player;
+import me.crypnotic.neutron.api.module.AbstractModule;
+import me.crypnotic.neutron.api.user.AbstractUser;
+import me.crypnotic.neutron.util.FileIO;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class UserModule extends AbstractModule {
+
+    private LoadingCache<UUID, PlayerUser> playerUsers;
+    private ConsoleUser consoleUser;
+
+    @Override
+    public boolean init() {
+        initCache();
+        consoleUser = new ConsoleUser(getRootNode().getNode("console"));
+
+        return true;
+    }
+
+    private void initCache() {
+        final int maxSize = getRootNode().getNode("cache", "maxSize").getInt(100);
+        final int expiryMins = getRootNode().getNode("cache", "expiry").getInt(30);
+
+        final CacheBuilder<UUID, PlayerUser> builder = CacheBuilder.newBuilder()
+            .weakKeys()
+            .removalListener(notification -> {
+                try {
+                    notification.getValue().save();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+
+        if (maxSize >= 0) {
+            builder.maximumSize(maxSize);
+        }
+
+        if (expiryMins >= 0) {
+            builder.expireAfterAccess(expiryMins, TimeUnit.MINUTES);
+        }
+
+        playerUsers = builder.build(new CacheLoader<UUID, PlayerUser>() {
+                @Override
+                public PlayerUser load(UUID uuid) throws Exception {
+                    PlayerUser user = new PlayerUser(uuid);
+                    user.load();
+                    return user;
+                }
+            });
+    }
+
+    @Override
+    public boolean reload() {
+        return shutdown() && init();
+    }
+
+    @Override
+    public boolean shutdown() {
+        playerUsers.asMap().keySet().forEach(playerUsers::invalidate);
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "user";
+    }
+
+    public AbstractUser getUser(UUID uuid) {
+        try {
+            return playerUsers.get(uuid);
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public AbstractUser getUser(CommandSource base) {
+        if (base instanceof Player) {
+            return getUser(((Player) base).getUniqueId());
+        } else if (base instanceof ConsoleCommandSource) {
+            return consoleUser;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/me/crypnotic/neutron/util/ConfigHelper.java
+++ b/src/main/java/me/crypnotic/neutron/util/ConfigHelper.java
@@ -27,6 +27,7 @@ package me.crypnotic.neutron.util;
 import com.google.common.reflect.TypeToken;
 
 import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 
 public class ConfigHelper {
@@ -35,6 +36,18 @@ public class ConfigHelper {
     public static <T> T getSerializable(ConfigurationNode node, T config) {
         try {
             return node.getValue(TypeToken.of((Class<T>) config.getClass()), config);
+        } catch (ObjectMappingException exception) {
+            exception.printStackTrace();
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T, U extends ConfigurationNode> U setSerializable(U node, T config) {
+        try {
+            U newNode = (U) node.copy();
+            newNode.setValue(TypeToken.of((Class<T>) config.getClass()), config);
+            return newNode;
         } catch (ObjectMappingException exception) {
             exception.printStackTrace();
         }

--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -30,6 +30,11 @@ command {
 			enabled = true
 			aliases = ["message", "msg", "tell", "whisper"]
 		}
+
+		reply {
+			enabled = true
+			aliases = ["reply", "r"]
+		}
 		
 		send {
 			enabled = true
@@ -77,4 +82,22 @@ serverlist {
 			"&7Powered by a &bNeutron"
 		]
 	}
+}
+
+user {
+    enabled = true
+
+    # Default settings for the console user
+    console {
+        name = "Console"
+    }
+
+    # Advanced settings controlling how users are kept in memory
+    cache {
+        # Maximum number of users to keep loaded
+        max-size = 100
+
+        # How long after its last access a user should stay loaded in minutes
+        expiry = 30
+    }
 }


### PR DESCRIPTION
This module provides a mechanism for Neutron to store and persist data about players, allowing things such as:
* Setting a nickname that persists across reconnections/proxy reboots
* Sending mail messages to offline players
* Remembering the last person they last messaged for the purpose of a `/reply` command (see separate PR)

This is loosely inspired by Essentials' user storage, though uses both Lombok and Configurate, massively reducing the size of the data class. Unlike Essentials however, `Player`s are represented by `PlayerUser`s, while `ConsoleCommandSender` is represented by `ConsoleUser`.

I'm not sure whether by a module or outside one - I wasn't planning to implement it in a module until I saw [i18n is also handled by a module](https://github.com/Crypnotic/Neutron/tree/master/src/main/java/me/crypnotic/neutron/module/locale).

I'd appreciate any feedback on how I've implemented this.