### PR TITLE
Add ConfigSerializable annotation to fix user module config

### DIFF
--- a/src/main/java/me/crypnotic/neutron/module/user/UserConfig.java
+++ b/src/main/java/me/crypnotic/neutron/module/user/UserConfig.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
+@ConfigSerializable
 public class UserConfig {
 
     @Getter


### PR DESCRIPTION
Fixes a NullPointerException when trying to access the UserConfig during the UserModule setup.