### PR TITLE
Implement join and quit messages

### DIFF
--- a/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
+++ b/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
@@ -32,6 +32,9 @@ public enum LocaleMessage {
 
     ALERT_MESSAGE("&7&l[&c&lALERT&7&l] &e{0}"),
 
+    CONNECT_JOIN_MESSAGE("&b{0} &7joined the network"),
+    CONNECT_QUIT_MESSAGE("&b{0} &7left the network"),
+
     FIND_MESSAGE("&b{0} &7is connected to &b{1}"),
 
     INFO_HEADER("&l&7==> Information for player: &b{0}"),

--- a/src/main/java/me/crypnotic/neutron/manager/ModuleManager.java
+++ b/src/main/java/me/crypnotic/neutron/manager/ModuleManager.java
@@ -38,6 +38,7 @@ import me.crypnotic.neutron.api.module.Module;
 import me.crypnotic.neutron.api.serializer.ComponentSerializer;
 import me.crypnotic.neutron.module.announcement.AnnouncementModule;
 import me.crypnotic.neutron.module.command.CommandModule;
+import me.crypnotic.neutron.module.connectmessage.ConnectMessageModule;
 import me.crypnotic.neutron.module.serverlist.ServerListModule;
 import net.kyori.text.Component;
 import ninja.leaping.configurate.ConfigurationNode;
@@ -54,6 +55,7 @@ public class ModuleManager implements Reloadable {
     @Override
     public StateResult init() {
         modules.put(AnnouncementModule.class, new AnnouncementModule());
+        modules.put(ConnectMessageModule.class, new ConnectMessageModule());
         modules.put(CommandModule.class, new CommandModule());
         modules.put(ServerListModule.class, new ServerListModule());
 

--- a/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageConfig.java
+++ b/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageConfig.java
@@ -1,0 +1,14 @@
+package me.crypnotic.neutron.module.connectmessage;
+
+import lombok.Getter;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class ConnectMessageConfig {
+
+    @Getter
+    @Setting("allow-silent-join-quit")
+    private boolean allowSilentJoinQuit = false;
+
+}

--- a/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageHandler.java
+++ b/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageHandler.java
@@ -1,0 +1,35 @@
+package me.crypnotic.neutron.module.connectmessage;
+
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.DisconnectEvent;
+import com.velocitypowered.api.event.connection.PostLoginEvent;
+import lombok.RequiredArgsConstructor;
+import me.crypnotic.neutron.api.locale.LocaleMessage;
+import me.crypnotic.neutron.util.StringHelper;
+import net.kyori.text.Component;
+
+@RequiredArgsConstructor
+public class ConnectMessageHandler {
+
+    private final ConnectMessageModule module;
+    private final ConnectMessageConfig config;
+
+    @Subscribe
+    public void onPlayerJoin(PostLoginEvent event) {
+        if (!module.isEnabled()) return;
+        if (config.isAllowSilentJoinQuit() && event.getPlayer().hasPermission("neutron.silentjoin")) return;
+
+        Component message = StringHelper.getMessage(event.getPlayer(), LocaleMessage.CONNECT_JOIN_MESSAGE, event.getPlayer().getUsername());
+        module.getNeutron().getProxy().broadcast(message);
+    }
+
+    @Subscribe
+    public void onPlayerQuit(DisconnectEvent event) {
+        if (!module.isEnabled()) return;
+        if (config.isAllowSilentJoinQuit() && event.getPlayer().hasPermission("neutron.silentquit")) return;
+
+        Component message = StringHelper.getMessage(event.getPlayer(), LocaleMessage.CONNECT_QUIT_MESSAGE, event.getPlayer().getUsername());
+        module.getNeutron().getProxy().broadcast(message);
+    }
+
+}

--- a/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageModule.java
+++ b/src/main/java/me/crypnotic/neutron/module/connectmessage/ConnectMessageModule.java
@@ -1,0 +1,43 @@
+package me.crypnotic.neutron.module.connectmessage;
+
+import lombok.Getter;
+import me.crypnotic.neutron.api.StateResult;
+import me.crypnotic.neutron.api.module.Module;
+import me.crypnotic.neutron.util.ConfigHelper;
+
+public class ConnectMessageModule extends Module {
+
+    @Getter
+    private ConnectMessageConfig config;
+
+    private ConnectMessageHandler handler;
+
+    @Override
+    public StateResult init() {
+        this.config = ConfigHelper.getSerializable(getRootNode(), new ConnectMessageConfig());
+        if (config == null) {
+            return StateResult.fail();
+        }
+
+        handler = new ConnectMessageHandler(this, config);
+        getNeutron().getProxy().getEventManager().register(getNeutron(), handler);
+
+        return StateResult.success();
+    }
+
+    @Override
+    public StateResult reload() {
+        return StateResult.of(shutdown(), init());
+    }
+
+    @Override
+    public StateResult shutdown() {
+        getNeutron().getProxy().getEventManager().unregisterListener(getNeutron(), handler);
+        return StateResult.success();
+    }
+
+    @Override
+    public String getName() {
+        return "connectmessages";
+    }
+}

--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -43,6 +43,16 @@ command {
 	}
 }
 
+connectmessages {
+	enabled = true
+
+	# If true, when a player has the permissions neutron.silentjoin or neutron.silentquit, Neutron
+	# will hide their join or quit messages respectively.
+	allow-silent-join-quit = false
+
+	# Join and quit messages can be configured in the locale file.
+}
+
 locale {
 	enabled = true
 	


### PR DESCRIPTION
Implement join and quit messages:
* The join and quit messages are defined in the locale
* The permissions `neutron.silentjoin` and `neutron.silentquit` can be used to hide join and quit messages for a player if `connectmessage.allow-silent-join-quit` is set to `true` in the config

I've taken the locale code from `CommandWrapper`, but I think this should be moved to reside with the locale code itself rather than being duplicated here.

Feel free to push any changes here as needed.