### PR TITLE
Implement nicknames

### DIFF
--- a/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
+++ b/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
@@ -49,6 +49,11 @@ public enum LocaleMessage {
     MESSAGE_SENDER("&b&lme \u00bb {0} &7> &o"),
     MESSAGE_RECEIVER("&b&l{0} \u00bb me &7> &o"),
 
+    NICKNAME_CLEAR("&aYou nickname has been cleared."),
+    NICKNAME_CURRENT("&aCurrent nickname: &r{0}"),
+    NICKNAME_NONE("&aYou don't have a nickname."),
+    NICKNAME_SET("&aYou nickname is now &r{0}&r&a."),
+
     NO_PERMISSION("&cYou don't have permission to execute this command."),
     NOT_CONNECTED_TO_SERVER("&cYou must be connected to a server to use this subcommand."),
 

--- a/src/main/java/me/crypnotic/neutron/api/user/User.java
+++ b/src/main/java/me/crypnotic/neutron/api/user/User.java
@@ -8,20 +8,83 @@ import com.velocitypowered.api.proxy.Player;
 
 public interface User<T extends CommandSource> {
 
+    /**
+     * Load the user's data from disk.
+     *
+     * @throws Exception if the data cannot be loaded.
+     */
     void load() throws Exception;
 
+    /**
+     * Save the user's data to disk, if applicable.
+     *
+     * @throws Exception if the data cannot be saved.
+     */
     void save() throws Exception;
-    
+
+    /**
+     * Get the base CommandSource this user is associated with.
+     *
+     * @return the base CommandSource
+     */
     Optional<T> getBase();
 
+    /**
+     * Get the name used to refer to the user. This may be their username or nickname.
+     * The console's preferred name is set in the config.
+     *
+     * @return the user's username or nickname
+     */
     String getName();
 
+    /**
+     * Get the nickname the user has set, if any.
+     *
+     * @return the nickname set, if any
+     */
+    String getNickname();
+
+    /**
+     * Get the CommandSource that the user will send a private message to when using /reply.
+     *
+     * @return the relevant CommandSource
+     */
     CommandSource getReplyRecipient();
-    
+
+    /**
+     * Get the user's username. This is undefined for non-player users.
+     *
+     * @return the username, if applicable
+     */
+    String getUsername();
+
+    /**
+     * Get the user's UUID.
+     *
+     * @return the user's UUID
+     */
     Optional<UUID> getUUID();
 
+    /**
+     * Set the user's nickname.
+     * This is ignored for the console user.
+     *
+     * @param nickname The nickname of the user.
+     */
+    void setNickname(String nickname);
+
+    /**
+     * Set the CommandSource that the user will send a private message to when using /reply.
+     *
+     * @param source the CommandSource to reply to
+     */
     void setReplyRecipient(CommandSource source);
 
+    /**
+     * Determine whether the user is a player or not.
+     *
+     * @return whether or not the user is a player
+     */
     default boolean isPlayer() {
         return getBase().isPresent() && getBase().get() instanceof Player;
     }

--- a/src/main/java/me/crypnotic/neutron/api/user/User.java
+++ b/src/main/java/me/crypnotic/neutron/api/user/User.java
@@ -30,8 +30,8 @@ public interface User<T extends CommandSource> {
     Optional<T> getBase();
 
     /**
-     * Get the name used to refer to the user. This may be their username or nickname.
-     * The console's preferred name is set in the config.
+     * Get the display name to refer to the user. This may be their username or nickname.
+     * The console's display name is set in the config.
      *
      * @return the user's username or nickname
      */

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/ConsoleUser.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/ConsoleUser.java
@@ -29,6 +29,16 @@ public class ConsoleUser implements User<ConsoleCommandSource> {
     }
 
     @Override
+    public String getNickname() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
     public void load() throws Exception {
         /* noop */
     }
@@ -41,5 +51,10 @@ public class ConsoleUser implements User<ConsoleCommandSource> {
     @Override
     public Optional<UUID> getUUID() {
         return Optional.empty();
+    }
+
+    @Override
+    public void setNickname(String nickname) {
+        /* noop */
     }
 }

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
@@ -19,15 +19,18 @@ class PlayerData {
     @Setting(comment = "The player's last known username.")
     private String username;
 
+    @Setting(comment = "The player's nickname.")
+    private String nickname;
+
     // Non-persisted data - this is not saved when the user is unloaded.
 
     private WeakReference<CommandSource> replyRecipient = null;
 
-    public CommandSource getReplyRecipient() {
+    CommandSource getReplyRecipient() {
         return replyRecipient != null ? replyRecipient.get() : null;
     }
 
-    public void setReplyRecipient(CommandSource replyRecipient) {
+    void setReplyRecipient(CommandSource replyRecipient) {
         this.replyRecipient = new WeakReference<>(replyRecipient);
     }
 }

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerUser.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerUser.java
@@ -50,12 +50,14 @@ public class PlayerUser implements User<Player> {
 
     @Override
     public String getName() {
-        Optional<Player> base = getBase();
-        if (base.isPresent()) {
-            return base.get().getUsername();
-        }
+        String nickname = getNickname();
+        return nickname == null ? getUsername() : "~" + nickname;
+    }
 
-        return data.getUsername();
+    @Override
+    public String getNickname() {
+        String nickname = data.getNickname();
+        return nickname == null || nickname.isEmpty() ? null : nickname;
     }
 
     @Override
@@ -63,8 +65,20 @@ public class PlayerUser implements User<Player> {
         return Optional.of(uuid);
     }
 
+    @Override
+    public void setNickname(String nickname) {
+        data.setNickname(nickname);
+    }
+
     public CommandSource getReplyRecipient() {
         return data.getReplyRecipient();
+    }
+
+    @Override
+    public String getUsername() {
+        Optional<Player> base = getBase();
+        return base.isPresent() ? base.get().getUsername() : data.getUsername();
+
     }
 
     public void setReplyRecipient(CommandSource source) {

--- a/src/main/java/me/crypnotic/neutron/module/command/Commands.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/Commands.java
@@ -38,6 +38,7 @@ public enum Commands {
     INFO("info", InfoCommand::new),
     GLIST("glist", GlistCommand::new),
     MESSAGE("message", MessageCommand::new),
+    NICKNAME("nickname", NicknameCommand::new),
     REPLY("reply", ReplyCommand::new),
     SEND("send", SendCommand::new);
 

--- a/src/main/java/me/crypnotic/neutron/module/command/options/NicknameCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/NicknameCommand.java
@@ -1,0 +1,45 @@
+package me.crypnotic.neutron.module.command.options;
+
+import com.velocitypowered.api.command.CommandSource;
+import me.crypnotic.neutron.api.command.CommandContext;
+import me.crypnotic.neutron.api.command.CommandWrapper;
+import me.crypnotic.neutron.api.locale.LocaleMessage;
+import me.crypnotic.neutron.api.user.User;
+
+public class NicknameCommand extends CommandWrapper {
+    @Override
+    public void handle(CommandSource source, CommandContext context) throws CommandExitException {
+        assertPermission(source, "neutron.command.nickname");
+        assertUsage(source, context.size() > 0);
+
+        User user = getUser(source).orElseThrow(CommandExitException::new);
+
+        assertCustom(source, user.isPlayer(), LocaleMessage.PLAYER_ONLY_COMMAND);
+
+        switch (context.get(0)) {
+            case "get":
+                if (user.getNickname() != null) {
+                    source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_CURRENT, user.getNickname()));
+                } else {
+                    source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_NONE));
+                }
+                break;
+            case "clear":
+                user.setNickname(null);
+                source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_CLEAR));
+                break;
+            case "set":
+                assertUsage(source, context.size() > 1);
+                user.setNickname(context.get(1));
+                source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_SET, user.getNickname()));
+                break;
+            default:
+                assertUsage(source, false);
+        }
+    }
+
+    @Override
+    public String getUsage() {
+        return "/nickname <get|clear|set <nickname>>";
+    }
+}

--- a/src/main/java/me/crypnotic/neutron/module/command/options/NicknameCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/NicknameCommand.java
@@ -19,19 +19,19 @@ public class NicknameCommand extends CommandWrapper {
         switch (context.get(0)) {
             case "get":
                 if (user.getNickname() != null) {
-                    source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_CURRENT, user.getNickname()));
+                    message(source, LocaleMessage.NICKNAME_CURRENT, user.getNickname());
                 } else {
-                    source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_NONE));
+                    message(source, LocaleMessage.NICKNAME_NONE);
                 }
                 break;
             case "clear":
                 user.setNickname(null);
-                source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_CLEAR));
+                message(source, LocaleMessage.NICKNAME_CLEAR);
                 break;
             case "set":
                 assertUsage(source, context.size() > 1);
                 user.setNickname(context.get(1));
-                source.sendMessage(getMessage(source, LocaleMessage.NICKNAME_SET, user.getNickname()));
+                message(source, LocaleMessage.NICKNAME_SET, user.getNickname());
                 break;
             default:
                 assertUsage(source, false);

--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -25,10 +25,15 @@ command {
 			enabled = false
 			aliases = ["glist"]
 		}
-		
+
 		message {
 			enabled = true
 			aliases = ["message", "msg", "tell", "whisper"]
+		}
+
+		nickname {
+			enabled = true
+			aliases = ["nickname", "nick"]
 		}
 
 		reply {


### PR DESCRIPTION
Add nicknames. Players can set their own using `/nickname set <nickname>`, check theirs using `/nickname get` and clear theirs with `/nickname clear`. Their nickname is used as their display name where appropriate.

I'm not convinced about the command syntax - should this be split into separate commands? In addition, this PR currently doesn't provide a way to see/check/clear other people's nicknames (which would be useful for moderators etc.).