### PR TITLE
Add /ignore command

### DIFF
--- a/src/main/java/me/crypnotic/neutron/api/command/CommandWrapper.java
+++ b/src/main/java/me/crypnotic/neutron/api/command/CommandWrapper.java
@@ -79,6 +79,12 @@ public abstract class CommandWrapper implements Command {
     }
 
     @SneakyThrows
+    public void assertNotIgnoring(CommandSource source, CommandSource ignoreSource, Player target, LocaleMessage message, Object... values) {
+        boolean ignoring = getUser(ignoreSource).map(user -> !user.isIgnoringPlayer(target)).orElse(false);
+        assertCustom(source, !ignoring, message, values);
+    }
+
+    @SneakyThrows
     public void assertPermission(CommandSource source, String permission) {
         assertCustom(source, source.hasPermission(permission), LocaleMessage.NO_PERMISSION);
     }

--- a/src/main/java/me/crypnotic/neutron/api/command/CommandWrapper.java
+++ b/src/main/java/me/crypnotic/neutron/api/command/CommandWrapper.java
@@ -80,7 +80,7 @@ public abstract class CommandWrapper implements Command {
 
     @SneakyThrows
     public void assertNotIgnoring(CommandSource source, CommandSource ignoreSource, Player target, LocaleMessage message, Object... values) {
-        boolean ignoring = getUser(ignoreSource).map(user -> !user.isIgnoringPlayer(target)).orElse(false);
+        boolean ignoring = getUser(ignoreSource).map(user -> user.isIgnoringPlayer(target)).orElse(false);
         assertCustom(source, !ignoring, message, values);
     }
 

--- a/src/main/java/me/crypnotic/neutron/api/command/CommandWrapper.java
+++ b/src/main/java/me/crypnotic/neutron/api/command/CommandWrapper.java
@@ -80,8 +80,7 @@ public abstract class CommandWrapper implements Command {
 
     @SneakyThrows
     public void assertNotIgnoring(CommandSource source, CommandSource ignoreSource, Player target, LocaleMessage message, Object... values) {
-        boolean ignoring = getUser(ignoreSource).map(user -> user.isIgnoringPlayer(target)).orElse(false);
-        assertCustom(source, !ignoring, message, values);
+        getUser(ignoreSource).ifPresent(u -> assertCustom(source, !u.isIgnoringPlayer(target), message, values));
     }
 
     @SneakyThrows

--- a/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
+++ b/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
@@ -37,6 +37,10 @@ public enum LocaleMessage {
 
     FIND_MESSAGE("&b{0} &7is connected to &b{1}"),
 
+    IGNORE_AMBIGUOUS_PLAYER("&cPlayer '{0}' is ambiguous; did you mean: {1}"),
+    IGNORE_NOW_IGNORING("&aYou are now ignoring {0}."),
+    IGNORE_NOW_NOT_IGNORING("&aYou are no longer ignoring {0}."),
+
     INFO_HEADER("&l&7==> Information for player: &b{0}"),
     INFO_LOCALE("&7Locale: &b{0}"),
     INFO_PING("&7Ping: &b{0}"),
@@ -49,6 +53,8 @@ public enum LocaleMessage {
     LIST_HEADER("&aThere are currently &b{0} &aplayers online\n&7&oHover over a server to see the players online"),
     LIST_MESSAGE("&a[{0}] &e{1} player{2} online"),
 
+    MESSAGE_IGNORED_BY_TARGET("&cYou can't message {0} right now."),
+    MESSAGE_IGNORING_TARGET("&cYou can't message {0} because you are ignoring them."),
     MESSAGE_SENDER("&b&lme \u00bb {0} &7> &o"),
     MESSAGE_RECEIVER("&b&l{0} \u00bb me &7> &o"),
 

--- a/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
+++ b/src/main/java/me/crypnotic/neutron/api/locale/LocaleMessage.java
@@ -38,6 +38,10 @@ public enum LocaleMessage {
     FIND_MESSAGE("&b{0} &7is connected to &b{1}"),
 
     IGNORE_AMBIGUOUS_PLAYER("&cPlayer '{0}' is ambiguous; did you mean: {1}"),
+    IGNORE_LIST_EMPTY("&aYou are not ignoring anyone."),
+    IGNORE_LIST_HEAD("&aYou are ignoring the following players:\n"),
+    IGNORE_LIST_ITEM("&f{0}&7, "),
+    IGNORE_LIST_ITEM_UNKNOWN("&f&ounknown&7, "),
     IGNORE_NOW_IGNORING("&aYou are now ignoring {0}."),
     IGNORE_NOW_NOT_IGNORING("&aYou are no longer ignoring {0}."),
 

--- a/src/main/java/me/crypnotic/neutron/api/user/User.java
+++ b/src/main/java/me/crypnotic/neutron/api/user/User.java
@@ -1,6 +1,7 @@
 package me.crypnotic.neutron.api.user;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.velocitypowered.api.command.CommandSource;
@@ -17,10 +18,18 @@ public interface User<T extends CommandSource> {
     String getName();
 
     CommandSource getReplyRecipient();
+
+    Set<UUID> getIgnoredPlayers();
     
     Optional<UUID> getUUID();
 
     void setReplyRecipient(CommandSource source);
+
+    void setIgnoringPlayer(Player target, boolean ignore);
+
+    default boolean isIgnoringPlayer(Player target) {
+        return getIgnoredPlayers().contains(target);
+    }
 
     default boolean isPlayer() {
         return getBase().isPresent() && getBase().get() instanceof Player;

--- a/src/main/java/me/crypnotic/neutron/api/user/User.java
+++ b/src/main/java/me/crypnotic/neutron/api/user/User.java
@@ -28,7 +28,7 @@ public interface User<T extends CommandSource> {
     void setIgnoringPlayer(Player target, boolean ignore);
 
     default boolean isIgnoringPlayer(Player target) {
-        return getIgnoredPlayers().contains(target);
+        return getIgnoredPlayers().contains(target.getUniqueId());
     }
 
     default boolean isPlayer() {

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/ConsoleUser.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/ConsoleUser.java
@@ -1,6 +1,8 @@
 package me.crypnotic.neutron.manager.user.holder;
 
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.velocitypowered.api.command.CommandSource;
@@ -41,5 +43,20 @@ public class ConsoleUser implements User<ConsoleCommandSource> {
     @Override
     public Optional<UUID> getUUID() {
         return Optional.empty();
+    }
+
+    @Override
+    public void setIgnoringPlayer(CommandSource source) {
+        /* noop */
+    }
+
+    @Override
+    public Set<CommandSource> getIgnoredPlayers() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isIgnoringPlayer(CommandSource source) {
+        return false;
     }
 }

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
@@ -1,5 +1,7 @@
 package me.crypnotic.neutron.manager.user.holder;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.velocitypowered.api.command.CommandSource;
 import lombok.Data;
 import ninja.leaping.configurate.objectmapping.Setting;
@@ -7,6 +9,7 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 import java.lang.ref.WeakReference;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -23,7 +26,15 @@ class PlayerData {
     private String username;
 
     @Setting(comment = "Players that this player is ignoring")
-    private Set<UUID> ignoredPlayers = Collections.emptySet();
+    private List<UUID> ignoredPlayers = Collections.emptyList(); // Configurate includes a List TypeSerializer, so let's use that.
+
+    public Set<UUID> getIgnoredPlayers() {
+        return Sets.newHashSet(ignoredPlayers);
+    }
+
+    public void setIgnoredPlayers(Set<UUID> ignoredPlayers) {
+        this.ignoredPlayers = Lists.newArrayList(ignoredPlayers);
+    }
 
     // Non-persisted data - this is not saved when the user is unloaded.
 

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
@@ -6,6 +6,7 @@ import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 
@@ -22,7 +23,7 @@ class PlayerData {
     private String username;
 
     @Setting(comment = "Players that this player is ignoring")
-    private Set<UUID> ignoredPlayers;
+    private Set<UUID> ignoredPlayers = Collections.emptySet();
 
     // Non-persisted data - this is not saved when the user is unloaded.
 

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerData.java
@@ -6,6 +6,8 @@ import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 import java.lang.ref.WeakReference;
+import java.util.Set;
+import java.util.UUID;
 
 @ConfigSerializable
 @Data
@@ -18,6 +20,9 @@ class PlayerData {
 
     @Setting(comment = "The player's last known username.")
     private String username;
+
+    @Setting(comment = "Players that this player is ignoring")
+    private Set<UUID> ignoredPlayers;
 
     // Non-persisted data - this is not saved when the user is unloaded.
 

--- a/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerUser.java
+++ b/src/main/java/me/crypnotic/neutron/manager/user/holder/PlayerUser.java
@@ -3,9 +3,12 @@ package me.crypnotic.neutron.manager.user.holder;
 import static me.crypnotic.neutron.api.Neutron.getNeutron;
 
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.collect.Sets;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 
@@ -67,7 +70,25 @@ public class PlayerUser implements User<Player> {
         return data.getReplyRecipient();
     }
 
+    @Override
+    public Set<UUID> getIgnoredPlayers() {
+        return Collections.unmodifiableSet(data.getIgnoredPlayers());
+    }
+
     public void setReplyRecipient(CommandSource source) {
         data.setReplyRecipient(source);
+    }
+
+    @Override
+    public void setIgnoringPlayer(Player target, boolean ignore) {
+        Set<UUID> newSet = Sets.newHashSet(data.getIgnoredPlayers());
+
+        if (ignore) {
+            newSet.add(target.getUniqueId());
+        } else {
+            newSet.remove(target.getUniqueId());
+        }
+
+        data.setIgnoredPlayers(Collections.unmodifiableSet(newSet));
     }
 }

--- a/src/main/java/me/crypnotic/neutron/module/command/Commands.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/Commands.java
@@ -35,6 +35,7 @@ import me.crypnotic.neutron.module.command.options.*;
 public enum Commands {
     ALERT("alert", AlertCommand::new),
     FIND("find", FindCommand::new),
+    IGNORE("ignore", IgnoreCommand::new),
     INFO("info", InfoCommand::new),
     GLIST("glist", GlistCommand::new),
     MESSAGE("message", MessageCommand::new),

--- a/src/main/java/me/crypnotic/neutron/module/command/options/IgnoreCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/IgnoreCommand.java
@@ -76,6 +76,6 @@ public class IgnoreCommand extends CommandWrapper {
 
     @Override
     public String getUsage() {
-        return "/ignore (player)";
+        return "/ignore [player]";
     }
 }

--- a/src/main/java/me/crypnotic/neutron/module/command/options/IgnoreCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/IgnoreCommand.java
@@ -1,0 +1,43 @@
+package me.crypnotic.neutron.module.command.options;
+
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import me.crypnotic.neutron.api.command.CommandContext;
+import me.crypnotic.neutron.api.command.CommandWrapper;
+import me.crypnotic.neutron.api.locale.LocaleMessage;
+import me.crypnotic.neutron.api.user.User;
+
+import java.util.Collection;
+
+public class IgnoreCommand extends CommandWrapper {
+    @Override
+    public void handle(CommandSource source, CommandContext context) throws CommandExitException {
+        assertPermission(source, "neutron.command.ignore");
+        assertPlayer(source, LocaleMessage.PLAYER_ONLY_COMMAND);
+        assertUsage(source, context.size() > 0);
+
+        Collection<Player> matches = getNeutron().getProxy().matchPlayer(context.get(0));
+        assertCustom(source, matches.size() != 0, LocaleMessage.UNKNOWN_PLAYER);
+        assertCustom(source, matches.size() < 2, LocaleMessage.IGNORE_AMBIGUOUS_PLAYER);
+        Player target = matches.stream().findFirst().get();
+
+        User user = getUser(source).get();
+
+        boolean newState = !user.isIgnoringPlayer(target);
+
+        if (context.size() > 1) {
+            newState = Boolean.parseBoolean(context.get(1));
+        }
+
+        user.setIgnoringPlayer(target, newState);
+
+        message(source,
+            user.isIgnoringPlayer(target) ? LocaleMessage.IGNORE_NOW_IGNORING : LocaleMessage.IGNORE_NOW_NOT_IGNORING,
+            target.getUsername());
+    }
+
+    @Override
+    public String getUsage() {
+        return "/ignore (player)";
+    }
+}

--- a/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
@@ -63,7 +63,7 @@ public class MessageCommand extends CommandWrapper {
         assertNotIgnoring(source, source, target, LocaleMessage.MESSAGE_IGNORING_TARGET);
 
         // Ensure target is not ignoring source
-        if (source instanceof Player && !source.hasPermission("neutron.message.ignore.bypass")) {
+        if (source instanceof Player && !source.hasPermission("neutron.command.message.ignore.bypass")) {
             assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
         }
 

--- a/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
@@ -63,7 +63,7 @@ public class MessageCommand extends CommandWrapper {
         assertNotIgnoring(source, source, target, LocaleMessage.MESSAGE_IGNORING_TARGET);
 
         // Ensure target is not ignoring source
-        if (source instanceof Player) {
+        if (source instanceof Player && !source.hasPermission("neutron.message.ignore.bypass")) {
             assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
         }
 

--- a/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
@@ -59,6 +59,14 @@ public class MessageCommand extends CommandWrapper {
         final Optional<User<? extends CommandSource>> sender = getUser(source);
         final Optional<User<? extends CommandSource>> recipient = getUser(target);
 
+        // Ensure source is not ignoring target
+        assertNotIgnoring(source, source, target, LocaleMessage.MESSAGE_IGNORING_TARGET);
+
+        // Ensure target is not ignoring source
+        if (source instanceof Player) {
+            assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
+        }
+
         UserPrivateMessageEvent event = new UserPrivateMessageEvent(sender, recipient, content, false);
 
         getNeutron().getProxy().getEventManager().fire(event).thenAccept(resultEvent -> {

--- a/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/MessageCommand.java
@@ -60,11 +60,11 @@ public class MessageCommand extends CommandWrapper {
         final Optional<User<? extends CommandSource>> recipient = getUser(target);
 
         // Ensure source is not ignoring target
-        assertNotIgnoring(source, source, target, LocaleMessage.MESSAGE_IGNORING_TARGET);
+        assertNotIgnoring(source, source, target, LocaleMessage.MESSAGE_IGNORING_TARGET, target.getUsername());
 
         // Ensure target is not ignoring source
         if (source instanceof Player && !source.hasPermission("neutron.command.message.ignore.bypass")) {
-            assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
+            assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET, target.getUsername());
         }
 
         UserPrivateMessageEvent event = new UserPrivateMessageEvent(sender, recipient, content, false);

--- a/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
@@ -66,7 +66,7 @@ public class ReplyCommand extends CommandWrapper {
         }
 
         // Ensure target is not ignoring source
-        if (source instanceof Player) {
+        if (source instanceof Player && !source.hasPermission("neutron.message.ignore.bypass")) {
             assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
         }
 

--- a/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
@@ -60,6 +60,16 @@ public class ReplyCommand extends CommandWrapper {
         final Optional<User<? extends CommandSource>> sender = getUser(source);
         final Optional<User<? extends CommandSource>> recipient = getUser(target);
 
+        // Ensure source is not ignoring target
+        if (target instanceof Player) {
+            assertNotIgnoring(source, source, (Player) target, LocaleMessage.MESSAGE_IGNORING_TARGET);
+        }
+
+        // Ensure target is not ignoring source
+        if (source instanceof Player) {
+            assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
+        }
+
         UserPrivateMessageEvent event = new UserPrivateMessageEvent(sender, recipient, content, true);
 
         getNeutron().getProxy().getEventManager().fire(event).thenAccept(resultEvent -> {

--- a/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
@@ -62,12 +62,12 @@ public class ReplyCommand extends CommandWrapper {
 
         // Ensure source is not ignoring target
         if (target instanceof Player) {
-            assertNotIgnoring(source, source, (Player) target, LocaleMessage.MESSAGE_IGNORING_TARGET);
+            assertNotIgnoring(source, source, (Player) target, LocaleMessage.MESSAGE_IGNORING_TARGET, targetName);
         }
 
         // Ensure target is not ignoring source
         if (source instanceof Player && !source.hasPermission("neutron.command.message.ignore.bypass")) {
-            assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
+            assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET, targetName);
         }
 
         UserPrivateMessageEvent event = new UserPrivateMessageEvent(sender, recipient, content, true);

--- a/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
+++ b/src/main/java/me/crypnotic/neutron/module/command/options/ReplyCommand.java
@@ -66,7 +66,7 @@ public class ReplyCommand extends CommandWrapper {
         }
 
         // Ensure target is not ignoring source
-        if (source instanceof Player && !source.hasPermission("neutron.message.ignore.bypass")) {
+        if (source instanceof Player && !source.hasPermission("neutron.command.message.ignore.bypass")) {
             assertNotIgnoring(source, target, (Player) source, LocaleMessage.MESSAGE_IGNORED_BY_TARGET);
         }
 

--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -15,6 +15,11 @@ command {
 			enabled = true
 			aliases = ["find"]
 		}
+
+		ignore {
+			enabled = true
+			aliases = ["ignore", "block"]
+		}
 		
 		info {
 			enabled = true

--- a/src/main/resources/locales/en_US.conf
+++ b/src/main/resources/locales/en_US.conf
@@ -5,6 +5,15 @@ connect_quit_message = "&b{0} &7left the network"
 
 find_message = "&b{0} &7is connected to &b{1}"
 
+
+ignore_ambiguous_player("&cplayer '{0}' is ambiguous; did you mean: {1}"
+ignore_list_empty = "&aYou are not ignoring anyone."
+ignore_list_head = "&aYou are ignoring the following players:\n"
+ignore_list_item = "&f{0}&7, "
+ignore_list_item_unknown = "&f&ounknown&7, "
+ignore_now_ignoring = "&aYou are now ignoring {0}."
+ignore_now_not_ignoring = "&aYou are no longer ignoring {0}."
+
 info_header = "&l&7==> Information for player = &b{0}"
 info_locale = "&7Locale = &b{0}"
 info_ping = "&7Ping = &b{0}"
@@ -17,6 +26,9 @@ invalid_usage = "&cUsage = {0}"
 list_header = "&aThere are currently &b{0} &aplayers online\n&7&oHover over a server to see the players online"
 list_message = "&a[{0}] &e{1} online"
 
+
+message_ignored_by_target = "&cYou can't message {0} right now."
+message_ignoring_target = "&cYou can't message {0} because you are ignoring them."
 message_sender = "&b&lme » {0} &7> &o"
 message_receiver = "&b&l{0} » me &7> &o"
 

--- a/src/main/resources/locales/en_US.conf
+++ b/src/main/resources/locales/en_US.conf
@@ -5,8 +5,7 @@ connect_quit_message = "&b{0} &7left the network"
 
 find_message = "&b{0} &7is connected to &b{1}"
 
-
-ignore_ambiguous_player("&cplayer '{0}' is ambiguous; did you mean: {1}"
+ignore_ambiguous_player = "&cplayer '{0}' is ambiguous; did you mean: {1}"
 ignore_list_empty = "&aYou are not ignoring anyone."
 ignore_list_head = "&aYou are ignoring the following players:\n"
 ignore_list_item = "&f{0}&7, "
@@ -25,7 +24,6 @@ invalid_usage = "&cUsage = {0}"
 
 list_header = "&aThere are currently &b{0} &aplayers online\n&7&oHover over a server to see the players online"
 list_message = "&a[{0}] &e{1} online"
-
 
 message_ignored_by_target = "&cYou can't message {0} right now."
 message_ignoring_target = "&cYou can't message {0} because you are ignoring them."


### PR DESCRIPTION
Add a `/ignore` command which lets players mark other players as ignored. Running `/ignore bob` will toggle whether "bob" is ignored or not, but this can be overridden by adding `true`/`false` at the end. A list of ignored players is available through the API and by running `/ignore` with no arguments.