### PR TITLE
Add ability to control online players along with max players

### DIFF
--- a/src/main/java/me/crypnotic/neutron/module/serverlist/ServerListConfig.java
+++ b/src/main/java/me/crypnotic/neutron/module/serverlist/ServerListConfig.java
@@ -1,27 +1,27 @@
 /*
-* This file is part of Neutron, licensed under the MIT License
-*
-* Copyright (c) 2020 Crypnotic <crypnoticofficial@gmail.com>
-* Copyright (c) 2020 Contributors
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+ * This file is part of Neutron, licensed under the MIT License
+ *
+ * Copyright (c) 2020 Crypnotic <crypnoticofficial@gmail.com>
+ * Copyright (c) 2020 Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.crypnotic.neutron.module.serverlist;
 
 import java.util.Arrays;
@@ -47,6 +47,10 @@ public class ServerListConfig {
     @Getter
     @Setting("server-preview")
     private ServerPreview serverPreview = new ServerPreview();
+
+    @Getter
+    @Setting("online-player-count")
+    private OnlinePlayerCount onlinePlayerCount = new OnlinePlayerCount();
 
     @ConfigSerializable
     public static class PlayerCount {
@@ -90,6 +94,29 @@ public class ServerListConfig {
             EMPTY,
             MESSAGE,
             PLAYERS;
+        }
+    }
+
+    @ConfigSerializable
+    public static class OnlinePlayerCount {
+
+        @Getter
+        @Setting(value = "action", comment = "      # The online player count has three different actions:\r\n" + "        # \r\n"
+                + "        # STATIC - online players will always be the value of `online-player-count`\r\n"
+                + "        # PING - online player count shows the sum of all backend servers' online player counts. Cached every 5 minutes\r\n"
+                + "        # CURRENT - online players matches number of players connected to the proxy\r\n" + "        #\r\n"
+                + "        # `online-player-count` is only used with the STATIC action")
+
+        private OnlinePlayerCountAction action = OnlinePlayerCountAction.CURRENT;
+
+        @Getter
+        @Setting("online-player-count")
+        private int onlinePlayerCount = 32;
+
+        public static enum OnlinePlayerCountAction {
+            STATIC,
+            PING,
+            CURRENT;
         }
     }
 }

--- a/src/main/java/me/crypnotic/neutron/module/serverlist/ServerListHandler.java
+++ b/src/main/java/me/crypnotic/neutron/module/serverlist/ServerListHandler.java
@@ -50,11 +50,22 @@ public class ServerListHandler {
         Builder builder = ServerPing.builder();
 
         builder.version(original.getVersion());
-        builder.onlinePlayers(playerCount);
 
         original.getFavicon().ifPresent(builder::favicon);
 
         builder.description(config.getMotd());
+
+        switch (config.getOnlinePlayerCount().getAction()) {
+            case STATIC:
+                builder.onlinePlayers(playerCount);
+                break;
+            case PING:
+                builder.onlinePlayers(module.getOnlinePlayerPing());
+                break;
+            case CURRENT:
+                builder.onlinePlayers(module.getNeutron().getProxy().getPlayerCount());
+                break;
+        }
 
         switch (config.getPlayerCount().getAction()) {
         case CURRENT:

--- a/src/main/java/me/crypnotic/neutron/module/serverlist/ServerListModule.java
+++ b/src/main/java/me/crypnotic/neutron/module/serverlist/ServerListModule.java
@@ -47,6 +47,8 @@ public class ServerListModule extends Module {
     private ServerListHandler handler;
     @Getter
     private int maxPlayerPing;
+    @Getter
+    private int onlinePlayerPing;
 
     @Override
     public StateResult init() {
@@ -90,6 +92,7 @@ public class ServerListModule extends Module {
     public class PingTask implements Runnable {
 
         int buffer = 0;
+        int onlineBuffer = 0;
 
         @Override
         public void run() {
@@ -100,6 +103,7 @@ public class ServerListModule extends Module {
 
                     if (players.isPresent()) {
                         buffer += players.get().getMax();
+                        onlineBuffer += players.get().getOnline();
                     }
                 } catch (InterruptedException | ExecutionException exception) {
                     /* Catch silently */
@@ -108,7 +112,9 @@ public class ServerListModule extends Module {
             }
 
             maxPlayerPing = buffer;
+            onlinePlayerPing = onlineBuffer;
             buffer = 0;
+            onlineBuffer = 0;
         }
     }
 }


### PR DESCRIPTION
This PR adds options to set online player counts, much like exists for the max player counts.

Adds the following settings:
```
    online-player-count {
        # The online player count has three different actions:
        #
        # STATIC - online players will always be the value of `online-player-count`
        # PING - online player count shows the sum of all backend servers' online player counts. Cached every 5 minutes
        # CURRENT - online players matches number of players connected to the proxy
        #
        # `online-player-count` is only used with the STATIC action
        action=CURRENT
        online-player-count=32
    }
```

I run a multi-proxy network (different geographic locations for each), previously each proxy's online player counts were constantly out of sync and didn't represent actual players on the network. For those in a similar situation (who don't have some kind of advanced multi-proxy system), the PING action would be quite useful.

The STATIC option I just implemented incase someone found it useful, and the CURRENT option mimics default behaviour.

Hopefully you can excuse git being strange with the header, not sure what happened there :>